### PR TITLE
Updates with recent Score best practices

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,5 +1,8 @@
 name: Main Pipeline
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "main" ]
 
+env:
+  SCORE_HUMANITEC_VERSION: 'latest'
+
 jobs:
 
   build-frontend:
@@ -47,34 +50,22 @@ jobs:
               - '**/score.yaml'
               - '**/humanitec.score.yaml'
       
-      # Override the image name and tag for services which the version built in previous steps
-      - name: Create overrides file
+      - name: install score-humanitec
         if: steps.changes.outputs.scorefiles == 'true'
-        run: |
-          wget -q https://github.com/mikefarah/yq/releases/download/v4.30.8/yq_linux_amd64 -O yq
-          chmod +x yq
-          mv yq /usr/local/bin
-
-          yq e -n ".containers.frontend.image = \"${{needs.build-frontend.outputs.IMAGE_NAME}}:${{needs.build-frontend.outputs.IMAGE_TAG}}\"" > frontend.overrides.score.yaml
-          yq e -n ".containers.moneyapi.image = \"${{needs.build-moneyapi.outputs.IMAGE_NAME}}:${{needs.build-moneyapi.outputs.IMAGE_TAG}}\"" > moneyapi.overrides.score.yaml
-          yq e -n ".containers.usersapi.image = \"${{needs.build-usersapi.outputs.IMAGE_NAME}}:${{needs.build-usersapi.outputs.IMAGE_TAG}}\"" > usersapi.overrides.score.yaml
-              
-      - name: Install score-humanitec
-        if: steps.changes.outputs.scorefiles == 'true'
-        run: |
-          wget https://github.com/score-spec/score-humanitec/releases/download/0.5.0/score-humanitec_0.5.0_linux_amd64.tar.gz
-          tar -xvf score-humanitec_0.5.0_linux_amd64.tar.gz
-          chmod +x score-humanitec
-          mv score-humanitec /usr/local/bin
+        uses: score-spec/setup-score@v2
+        with:
+          file: score-humanitec
+          token: ${{ secrets.GITHUB_TOKEN }}
+          version: ${{ env.SCORE_HUMANITEC_VERSION }}
 
       - name: Run Score - Money API
         if: steps.changes.outputs.scorefiles == 'true'
-        run: score-humanitec delta --retry --deploy --token ${{ secrets.HUMANITEC_TOKEN }} --org ${{ vars.HUMANITEC_ORG }} --app bank-demo --env development -f money-api/score.yaml --overrides moneyapi.overrides.score.yaml
+        run: score-humanitec delta --retry --deploy --token ${{ secrets.HUMANITEC_TOKEN }} --org ${{ vars.HUMANITEC_ORG }} --app bank-demo --env development -f money-api/score.yaml --property containers.moneyapi.image=${{needs.build-moneyapi.outputs.IMAGE_NAME}}:${{needs.build-moneyapi.outputs.IMAGE_TAG}}
       
       - name: Run Score - Users API
         if: steps.changes.outputs.scorefiles == 'true'
-        run: score-humanitec delta --retry --deploy --token ${{ secrets.HUMANITEC_TOKEN }} --org ${{ vars.HUMANITEC_ORG }} --app bank-demo --env development -f users-api/score.yaml --overrides usersapi.overrides.score.yaml
+        run: score-humanitec delta --retry --deploy --token ${{ secrets.HUMANITEC_TOKEN }} --org ${{ vars.HUMANITEC_ORG }} --app bank-demo --env development -f users-api/score.yaml --property containers.usersapi.image=${{needs.build-usersapi.outputs.IMAGE_NAME}}:${{needs.build-usersapi.outputs.IMAGE_TAG}}
 
       - name: Run Score - Frontend
         if: steps.changes.outputs.scorefiles == 'true'
-        run: score-humanitec delta --retry --deploy --token ${{ secrets.HUMANITEC_TOKEN }} --org ${{ vars.HUMANITEC_ORG }} --app bank-demo --env development -f frontend/score.yaml --extensions frontend/humanitec.score.yaml --overrides frontend.overrides.score.yaml
+        run: score-humanitec delta --retry --deploy --token ${{ secrets.HUMANITEC_TOKEN }} --org ${{ vars.HUMANITEC_ORG }} --app bank-demo --env development -f frontend/score.yaml --extensions frontend/humanitec.score.yaml --property containers.frontend.image=${{needs.build-frontend.outputs.IMAGE_NAME}}:${{needs.build-frontend.outputs.IMAGE_TAG}}

--- a/frontend/score.yaml
+++ b/frontend/score.yaml
@@ -30,9 +30,5 @@ resources:
     type: dns
   moneyapi:
     type: service
-    properties:
-      name:
   usersapi:
     type: service
-    properties:
-      name:

--- a/money-api/score.yaml
+++ b/money-api/score.yaml
@@ -31,9 +31,3 @@ containers:
 resources:
   db:
     type: mysql
-    properties:
-      name:
-      username:
-      password:
-      host:
-      port:

--- a/report-worker/score.yaml
+++ b/report-worker/score.yaml
@@ -18,3 +18,7 @@ containers:
       AWS_ACCESS_KEY_ID: ${resources.s3.aws_access_key_id}
       AWS_SECRET_ACCESS_KEY: ${resources.s3.aws_secret_access_key}
       AWS_BUCKET_NAME: ${resources.s3.bucket}
+
+resources:
+  s3:
+    type: s3


### PR DESCRIPTION
- Remove `properties` on dependencies, not needed
- Use `score-spec/setup-score` action to install `score-humanitec`
- Add missing `s3` dependency in `report-worker`
- Use `--property` to inject the image name/tag while running `score-humanitec delta` instead of `yq`, etc.